### PR TITLE
refactor(javajdk): avoid excessive Jinja by using the YAML maps

### DIFF
--- a/nifi/defaults.yaml
+++ b/nifi/defaults.yaml
@@ -10,9 +10,9 @@ nifi:
     version: 1.11.4
     installdir: /opt
 
-    # Options for OpenJDK. Version must match exact package name on system.
-    javajdk: true
-    javajdkversion: 8
+    # OpenJDK package name on system; defaults to an empty string, which avoids
+    # installing OpenJDK.  Overridden in the `os*map.yaml` files.
+    javajdk: ''
 
   systemdconfig:
     user: root

--- a/nifi/osfamilymap.yaml
+++ b/nifi/osfamilymap.yaml
@@ -10,9 +10,13 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfamilymap: {}
 ---
-Debian: {}
+Debian:
+  pkg:
+    javajdk: 'openjdk-11-jdk'
 
-RedHat: {}
+RedHat:
+  pkg:
+    javajdk: 'java-11-openjdk'
 
 Suse: {}
 

--- a/nifi/osfingermap.yaml
+++ b/nifi/osfingermap.yaml
@@ -12,12 +12,18 @@
 ---
 # os: Debian
 Debian-10: {}
-Debian-9: {}
-Debian-8: {}
+Debian-9:
+  pkg:
+    javajdk: 'openjdk-8-jdk'
+Debian-8:
+  pkg:
+    javajdk: 'openjdk-7-jdk'
 
 # os: Ubuntu
 Ubuntu-18.04: {}
-Ubuntu-16.04: {}
+Ubuntu-16.04:
+  pkg:
+    javajdk: 'openjdk-8-jdk'
 
 # os: Fedora
 Fedora-31: {}
@@ -26,7 +32,9 @@ Fedora-30: {}
 # os: CentOS
 CentOS Linux-8: {}
 CentOS Linux-7: {}
-CentOS-6: {}
+CentOS-6:
+  pkg:
+    javajdk: 'java-1.8.0-openjdk'
 
 # os: Amazon
 Amazon Linux-2: {}

--- a/nifi/osmap.yaml
+++ b/nifi/osmap.yaml
@@ -17,7 +17,9 @@ Raspbian: {}
 # os_family: RedHat
 Fedora: {}
 CentOS: {}
-Amazon: {}
+Amazon:
+  pkg:
+    javajdk: 'java-1.8.0-openjdk'
 
 # os_family: Suse
 SUSE: {}

--- a/nifi/package/javajdk.sls
+++ b/nifi/package/javajdk.sls
@@ -5,32 +5,8 @@
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import nifi with context %}
 
-{% if nifi.pkg.javajdk %}
-{% if grains['os_family']=="RedHat" %}
-{% if nifi.pkg['javajdkversion'] == 8 %}
+{%- if nifi.pkg.javajdk %}
 nifi-package-install-dependency-javajdk:
   pkg.installed:
-    - name: java-1.8.0-openjdk
-{% endif %}
-{% if nifi.pkg['javajdkversion'] == 11 %}
-nifi-package-install-dependency-javajdk:
-  pkg.installed:
-    - name: java-11-openjdk
-{% endif %}
-{% endif %}
-
-{% if grains['os_family']=="Debian" %}
-{% if nifi.pkg['javajdkversion'] == 8 %}
-nifi-package-install-dependency-javajdk:
-  pkg.installed:
-    - name: openjdk-8-jdk
-{% endif %}
-{% if nifi.pkg['javajdkversion'] == 11 %}
-nifi-package-install-dependency-javajdk:
-  pkg.installed:
-    - name: default-jdk
-{% endif %}
-{% endif %}
-
-{% endif %}
-
+    - name: {{ nifi.pkg.javajdk }}
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -10,9 +10,9 @@ nifi:
     version: 1.11.4
     installdir: /opt
 
-    # Options for OpenJDK. Version must match exact package name on system.
-    javajdk: true
-    javajdkversion: 8
+    # Override OpenJDK package to be installed, if value in `osfamilymap.yaml`
+    # is not appropriate; e.g. for `RedHat`:
+    # javajdk: 'java-11-openjdk'
 
   systemdconfig:
     user: root


### PR DESCRIPTION
With regards to: https://github.com/codeboyQ2n5ha45/nifi-formula/pull/4#issuecomment-609025465.

Changes would need to be made to the instructions in the `README` as well, if this gets merged, but I've left that since both `README` files are to be merged.

Note, `debian-10` is also working now but I haven't enabled it yet, since we don't usually want more than 6 instances running.  We can rearrange the matrix at a later time.